### PR TITLE
Fix Prevent Boosting & add Creative support

### DIFF
--- a/gamemode/gamemodes/nzombies/gamemode/anticheat/sh_nocrouchjump.lua
+++ b/gamemode/gamemodes/nzombies/gamemode/anticheat/sh_nocrouchjump.lua
@@ -13,7 +13,7 @@ local function Notify()
 end
 
 hook.Add("StartCommand", "ACNoCrouchJump", function(ply, ucmd)
-    if (nzMapping.Settings.ac and nzMapping.Settings.acpreventcjump) then
+    if (nzMapping.Settings.ac and nzMapping.Settings.acpreventcjump and !ply:IsInCreative()) then
         local isDucking = bit.band(ucmd:GetButtons(), IN_DUCK) == IN_DUCK
         local isJumping = bit.band(ucmd:GetButtons(), IN_JUMP) == IN_JUMP
         

--- a/gamemode/gamemodes/nzombies/gamemode/anticheat/sv_anti-cheat.lua
+++ b/gamemode/gamemodes/nzombies/gamemode/anticheat/sv_anti-cheat.lua
@@ -292,9 +292,11 @@ hook.Add("PlayerTick", "NZAntiCheat", function(ply) -- Scan for players who are 
             ply:OnCheating()
         end
 
-        if (nzMapping.Settings.ac and nzMapping.Settings.acpreventboost) then -- Stop boosting
+        if (nzMapping.Settings.ac and nzMapping.Settings.acpreventboost and !ply:IsInCreative()) then -- Stop boosting fast upwards
             if (ply:GetVelocity()[3] >= ply:GetJumpPower()) then
-                ply:SetVelocity(Vector(0, 0, math.abs(ply:GetVelocity()[3])) * -1) -- Cancel out their speed
+                timer.Simple(0, function()
+                    ply:SetVelocity(Vector(0, 0, -math.abs(ply:GetVelocity()[3])))
+                end) 
             end
         end
     end


### PR DESCRIPTION
Prevent Boosting did NOT apply velocity changes 100% of the time, however by waiting 1 tick after the player is boosting the velocity change effects them every time.

Also, adds support for Creative Mode (Prevent Boosting and Prevent Crouch Jumping no longer takes effect in Creative Mode)