### PR TITLE
Bo3 Perk machine off models

### DIFF
--- a/gamemode/gamemodes/nzombies/gamemode/perks/sh_perks.lua
+++ b/gamemode/gamemodes/nzombies/gamemode/perks/sh_perks.lua
@@ -54,8 +54,9 @@ end
 
 nzPerks:NewPerk("jugg", {
 	name = "Juggernog",
-	off_model = "models/alig96/perks/jugg/jugg_off.mdl",
-	on_model = "models/yolojoenshit/bo3perks/juggernog/mc_mtl_p7_zm_vending_jugg.mdl",
+	model = "models/yolojoenshit/bo3perks/juggernog/mc_mtl_p7_zm_vending_jugg.mdl",
+	off_skin = 1,
+	on_skin = 0,
 	price = 2500,
 	material = "models/perk_bottle/c_perk_bottle_jugg",
 	icon = Material("perk_icons/chron/jugg.png", "smooth unlitgeneric"),
@@ -110,8 +111,9 @@ nzPerks:NewPerk("dtap", {
 
 nzPerks:NewPerk("revive", {
 	name = "Quick Revive",
-	off_model = "models/alig96/perks/revive/revive_off.mdl",
-	on_model = "models/yolojoenshit/bo3perks/revivesoda/mc_mtl_p7_zm_vending_revive.mdl",
+	model = "models/yolojoenshit/bo3perks/revivesoda/mc_mtl_p7_zm_vending_revive.mdl",
+	off_skin = 1,
+	on_skin = 0,
 	price = 1500,
 	material = "models/perk_bottle/c_perk_bottle_revive",
 	icon = Material("perk_icons/chron/revive.png", "smooth unlitgeneric"),
@@ -133,8 +135,9 @@ nzPerks:NewPerk("revive", {
 
 nzPerks:NewPerk("speed", {
 	name = "Speed Cola",
-	off_model = "models/alig96/perks/speed/speed_off.mdl",
-	on_model = "models/yolojoenshit/bo3perks/speedcola/mc_mtl_p7_zm_vending_speedcola.mdl",
+	model = "models/yolojoenshit/bo3perks/speedcola/mc_mtl_p7_zm_vending_speedcola.mdl",
+	off_skin = 1,
+	on_skin = 0,
 	price = 3000,
 	material = "models/perk_bottle/c_perk_bottle_speed",
 	icon = Material("perk_icons/chron/speed.png", "smooth unlitgeneric"),
@@ -171,8 +174,9 @@ nzPerks:NewPerk("speed", {
 
 nzPerks:NewPerk("pap", {
 	name = "Pack-a-Punch",
-	off_model = "models/alig96/perks/packapunch/packapunch.mdl", //Find a new model.
-	on_model = "models/yolojoenshit/extras/packapunch/mc_mtl_p7_packapunch.mdl",
+	model = "models/yolojoenshit/extras/packapunch/mc_mtl_p7_packapunch.mdl",
+	off_skin = 1,
+	on_skin = 0,
 	price = 0,
 	specialmachine = true, -- Prevents players from getting the perk when they buy it
 	nobuy = true, -- A "Buy" event won't run when this is used (we do that ourselves in its function)
@@ -317,8 +321,9 @@ nzPerks:NewPerk("pap", {
 
 nzPerks:NewPerk("dtap2", {
 	name = "Double Tap II",
-	off_model = "models/alig96/perks/doubletap2/doubletap2_off.mdl",
-	on_model = "models/yolojoenshit/bo3perks/doubletap2/mc_mtl_p7_zm_vending_doubletap2.mdl",
+	model = "models/yolojoenshit/bo3perks/doubletap2/mc_mtl_p7_zm_vending_doubletap2.mdl",
+	off_skin = 1,
+	on_skin = 0,
 	price = 2000,
 	material = "models/perk_bottle/c_perk_bottle_dtap2",
 	icon = Material("perk_icons/chron/dtap2.png", "smooth unlitgeneric"),
@@ -355,8 +360,9 @@ nzPerks:NewPerk("dtap2", {
 
 nzPerks:NewPerk("staminup", {
 	name = "Stamin-Up",
-	off_model = "models/alig96/perks/staminup/staminup_off.mdl",
-	on_model = "models/yolojoenshit/bo3perks/staminup/mc_mtl_p7_zm_vending_marathon.mdl",
+	model = "models/yolojoenshit/bo3perks/staminup/mc_mtl_p7_zm_vending_marathon.mdl",
+	off_skin = 1,
+	on_skin = 0,
 	price = 2000,
 	material = "models/perk_bottle/c_perk_bottle_stamin",
 	icon = Material("perk_icons/chron/staminup.png", "smooth unlitgeneric"),
@@ -509,8 +515,9 @@ nzPerks:NewPerk("phd", {
 
 nzPerks:NewPerk("deadshot", {
 	name = "Deadshot Daiquiri",
-	off_model = "models/alig96/perks/deadshot/deadshot_off.mdl",
-	on_model = "models/yolojoenshit/bo3perks/deadshot/mc_mtl_p7_zm_vending_deadshot.mdl",
+	model = "models/yolojoenshit/bo3perks/deadshot/mc_mtl_p7_zm_vending_deadshot.mdl",
+	off_skin = 1,
+	on_skin = 0,
 	price = 2000,
 	material = "models/perk_bottle/c_perk_bottle_deadshot",
 	icon = Material("perk_icons/chron/deadshot.png", "smooth unlitgeneric"),
@@ -523,8 +530,9 @@ nzPerks:NewPerk("deadshot", {
 
 nzPerks:NewPerk("mulekick", {
 	name = "Mule Kick",
-	off_model = "models/alig96/perks/mulekick/mulekick_off.mdl",
-	on_model = "models/yolojoenshit/bo3perks/mulekick/mc_mtl_p7_zm_vending_mulekick.mdl",
+	model = "models/yolojoenshit/bo3perks/mulekick/mc_mtl_p7_zm_vending_mulekick.mdl",
+	off_skin = 1,
+	on_skin = 0,
 	price = 4000,
 	material = "models/perk_bottle/c_perk_bottle_mulekick",
 	icon = Material("perk_icons/chron/mulekick.png", "smooth unlitgeneric"),


### PR DESCRIPTION
Bo3 perk machine models now have off skins.
Uses the same system as widows wine to change the skins of bo3 perk machines (including pap) when off.

All changes working on my end while only using your content packs.