### PR TITLE
Port translated undo notification message from Garry's Mod files

### DIFF
--- a/gamemode/gamemodes/nzombies/gamemode/display/cl_gamemodehooks.lua
+++ b/gamemode/gamemodes/nzombies/gamemode/display/cl_gamemodehooks.lua
@@ -8,10 +8,26 @@ function GM:PopulateMenuBar(panel)
 end
 
 function GM:OnUndo( name, strCustomString )
-	if ( !strCustomString ) then
-		notification.AddLegacy( "Undone "..name, NOTIFY_UNDO, 2 )
-	else	
-		notification.AddLegacy( strCustomString, NOTIFY_UNDO, 2 )
+
+	local text = strCustomString
+
+	if ( !text ) then
+		local strId = "#Undone_" .. name
+		text = language.GetPhrase( strId )
+		if ( strId == text ) then
+			-- No translation available, generate our own
+			text = string.format( language.GetPhrase( "hint.undoneX" ), language.GetPhrase( name ) )
+		end
 	end
+
+	-- This is a hack for SWEPs, Tools, etc, that already have hardcoded English only translations
+	local strMatch = string.match( text, "^Undone (.*)$" )
+	if ( strMatch ) then
+		text = string.format( language.GetPhrase( "hint.undoneX" ), language.GetPhrase( strMatch ) )
+	end
+
+	self:AddNotify( text, NOTIFY_UNDO, 2 )
+
 	surface.PlaySound( "buttons/button15.wav" )
+
 end


### PR DESCRIPTION
Current nZombies using outdated code without translated Undo message, so i just copied and pasted one from gmod's repository. https://github.com/Facepunch/garrysmod/blob/3d3fca86ffc4c4d7107d1bae6139c4aba44f3564/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua#L46