### PR TITLE
Fix cso weapons

### DIFF
--- a/gamemode/gamemodes/nzombies/gamemode/weapons/sh_weps.lua
+++ b/gamemode/gamemodes/nzombies/gamemode/weapons/sh_weps.lua
@@ -118,6 +118,14 @@ function wepMeta:IsTFA()
 	return false
 end
 
+function wepMeta:IsCSO() -- CSO has a perfix of tfa, so using IsTFA() and IsCSO() at the same time is redundant.
+	if string.sub(self:GetClass(), 1, 7) == "tfa_cso_" then -- This is enough to detect CSO
+		return true
+	end
+
+	return false
+end
+
 function wepMeta:CanRerollPaP()
 	return (self.OnRePaP or (self.Attachments and ((self:IsCW2() and CustomizableWeaponry) or self:IsTFA()) or self:IsFAS2()))
 end

--- a/gamemode/gamemodes/nzombies/gamemode/weapons/sh_weps.lua
+++ b/gamemode/gamemodes/nzombies/gamemode/weapons/sh_weps.lua
@@ -119,7 +119,7 @@ function wepMeta:IsTFA()
 end
 
 function wepMeta:IsCSO() -- CSO has a perfix of tfa, so using IsTFA() and IsCSO() at the same time is redundant.
-	if string.sub(self:GetClass(), 1, 7) == "tfa_cso_" then -- This is enough to detect CSO
+	if string.sub(self:GetClass(), 1, 8) == "tfa_cso_" then -- This is enough to detect CSO
 		return true
 	end
 

--- a/gamemode/gamemodes/nzombies/gamemode/weapons/sv_weps.lua
+++ b/gamemode/gamemodes/nzombies/gamemode/weapons/sv_weps.lua
@@ -29,6 +29,9 @@ function GetPriorityWeaponSlot(ply)
 	end
 	-- If we didn't return before (all slots taken), check the activeweapon
 	local activewep = ply:GetActiveWeapon()
+	
+	if activewep:IsCSO() then activewep = ply:GetInternalVariable("m_hLastWeapon") end -- In CSO, it should be the last active weapon instead of the active weapon
+	
 	local id = activewep:GetNWInt("SwitchSlot")
 	-- Only replace it if it has an ID (default is 0)
 	if id > 0 then


### PR DESCRIPTION
CSO weapons become active too quickly and should be checked for the last active weapon.